### PR TITLE
poolnet - bridge - create operator flow support + overall refactoring on imports and typos

### DIFF
--- a/x/bridge/README.md
+++ b/x/bridge/README.md
@@ -5,7 +5,7 @@
 
 # Bridge Module
 The bridge module is responsible for creating, signing and managing messages from ethereum <-> Pools network.<br/>
-The bridge model is heavily inspired by the Cosmos [Peggy](https://github.com/cosmos/peggy) project.
+The bridge model is heavily inspired by the Cosmos [Gravity Bridge](https://github.com/cosmos/gravity-bridge) project.
 
 ## Operator set changes
 The basic security assumption for the ethereum bridge contract is that only finalized events from the pools network to the ethereum get committed. 
@@ -13,14 +13,14 @@ A committed event is an event that has 2/3 of the current pools operator set sig
 A key part of "counting" signatures is for the ethereum bridge to be aware of the updated current operator set, this is done by having the operator set of time X sign on the next operator set (changes) at time X+1.<br/>
 
 The operator set update is done by initiating an operator set change request on the pools chain, then each operator signs the request. 
-Once it reaches 2/3 votes it can be broadcasted to the ethereum chain, if the signatures are valid, the operator set in the contract will get updated.
+Once it reaches 2/3 votes it can be broadcast to the ethereum chain, if the signatures are valid, the operator set in the contract will get updated.
 
 ## ethereum -> pools
 Individual operators will index transactions sent to the ethereum bridge contract and will submit claims to the pools network. 
 A claim is just an event detected on ethereum that an operator would like to commit.
 
 Ethereum has [probabilistic finality](https://medium.com/mechanism-labs/finality-in-blockchain-consensus-d1f83c120a9a) while tendermint has an absolute (deterministic) finality as a pBFT protocol. 
-This can cause issues when trying to commit evets from ethereum to a pBFT potocol as ethereum can experience forks while tendermint's finalized checkpoints can't.
+This can cause issues when trying to commit events from ethereum to a pBFT protocol as ethereum can experience forks while tendermint's finalized checkpoints can't.
 To solve this issue, events from ethereum (in the forms of claims) will only be communicated to the pools network if [enough](https://github.com/ethereum/annotated-spec/blob/master/phase0/beacon-chain.md#misc) confirmations have occured.<br/>
 The eth2 beacon chain solves this issue by having validators "attest" to blocks including events (deposits) from eth1, including an event in a block is made possible because the beacon chain finalizes (happy flow) every 32 blocks (epoch). 
 Tendermint finalizes every epoch, why not just include a claim in a block and wait for it to finalize? That could halt the tendermint chain in case of an ethereum fork, we need to simulate the voting mechanism as in eth2. 

--- a/x/bridge/ante/ante.go
+++ b/x/bridge/ante/ante.go
@@ -3,14 +3,14 @@ package ante
 import (
 	"fmt"
 
-	"github.com/bloxapp/pools-network/x/bridge/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	bridgeTypes "github.com/bloxapp/pools-network/x/bridge/types"
+	sdkTypes "github.com/cosmos/cosmos-sdk/types"
+	sdkErrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 type paramsGetter interface {
 	// GetParams should return the Bridge module's params set
-	GetParams(ctx sdk.Context) types.Params
+	GetParams(ctx sdkTypes.Context) bridgeTypes.Params
 }
 
 func NewMsgEthereumClaimAnteHandler(keeper paramsGetter) MsgEthereumClaimAnteHandler {
@@ -21,20 +21,20 @@ type MsgEthereumClaimAnteHandler struct {
 	keeper paramsGetter
 }
 
-var ErrInvalidMsg = fmt.Errorf("Ivalid MsgEthereumClaimAnteHandler")
+var ErrInvalidMsg = fmt.Errorf("Invalid MsgEthereumClaimAnteHandler")
 
-func (sud MsgEthereumClaimAnteHandler) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+func (sud MsgEthereumClaimAnteHandler) AnteHandle(ctx sdkTypes.Context, tx sdkTypes.Tx, simulate bool, next sdkTypes.AnteHandler) (newCtx sdkTypes.Context, err error) {
 	params := sud.keeper.GetParams(ctx)
 
 	for _, msg := range tx.GetMsgs() {
-		claims, ok := msg.(*types.MsgEthereumClaim)
+		claims, ok := msg.(*bridgeTypes.MsgEthereumClaim)
 		if !ok {
 			continue
 		}
 
 		// max delegate number
 		if uint64(len(claims.Data)) > params.MaxClaims {
-			return ctx, sdkerrors.Wrapf(ErrInvalidMsg,
+			return ctx, sdkErrors.Wrapf(ErrInvalidMsg,
 				"maximum number of claims is %d but received %d",
 				params.MaxClaims, len(claims.Data),
 			)

--- a/x/bridge/ante/ante_test.go
+++ b/x/bridge/ante/ante_test.go
@@ -3,19 +3,19 @@ package ante
 import (
 	"testing"
 
-	types2 "github.com/bloxapp/pools-network/shared/types"
+	sharedTypes "github.com/bloxapp/pools-network/shared/types"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bloxapp/pools-network/x/bridge/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	bridgeTypes "github.com/bloxapp/pools-network/x/bridge/types"
+	sdkTypes "github.com/cosmos/cosmos-sdk/types"
 )
 
 type TxTest struct {
-	msgs []sdk.Msg
+	msgs []sdkTypes.Msg
 }
 
-func (tx TxTest) GetMsgs() []sdk.Msg {
+func (tx TxTest) GetMsgs() []sdkTypes.Msg {
 	return tx.msgs
 }
 
@@ -24,26 +24,26 @@ func (tx TxTest) ValidateBasic() error {
 }
 
 type paramsProvider struct {
-	p types.Params
+	p bridgeTypes.Params
 }
 
-func (p paramsProvider) GetParams(ctx sdk.Context) types.Params {
+func (p paramsProvider) GetParams(ctx sdkTypes.Context) bridgeTypes.Params {
 	return p.p
 }
 
-func validClaim() types.ClaimData {
-	return types.ClaimData{
+func validClaim() bridgeTypes.ClaimData {
+	return bridgeTypes.ClaimData{
 		TxHash:             []byte{1, 2, 3, 4},
 		ClaimNonce:         1,
-		ClaimType:          types.ClaimType_Delegate,
-		EthereumAddresses:  []types2.EthereumAddress{{1, 2, 3, 4}, {1, 2, 3, 4}},
-		ConsensusAddresses: []types2.ConsensusAddress{{1, 2, 3, 4}},
+		ClaimType:          bridgeTypes.ClaimType_Delegate,
+		EthereumAddresses:  []sharedTypes.EthereumAddress{{1, 2, 3, 4}, {1, 2, 3, 4}},
+		ConsensusAddresses: []sharedTypes.ConsensusAddress{{1, 2, 3, 4}},
 		Values:             []uint64{1},
 	}
 }
 
-func populateWithClaims(claim types.ClaimData, length uint64) []types.ClaimData {
-	ret := make([]types.ClaimData, length)
+func populateWithClaims(claim bridgeTypes.ClaimData, length uint64) []bridgeTypes.ClaimData {
+	ret := make([]bridgeTypes.ClaimData, length)
 	for i := uint64(0); i < length; i++ {
 		ret[i] = claim
 	}
@@ -53,39 +53,39 @@ func populateWithClaims(claim types.ClaimData, length uint64) []types.ClaimData 
 func TestNewMsgEthereumClaimAnteHandler(t *testing.T) {
 	tests := []struct {
 		name             string
-		msgEthereumClaim *types.MsgEthereumClaim
+		msgEthereumClaim *bridgeTypes.MsgEthereumClaim
 		errStr           string
 	}{
 		{
 			name: "valid",
-			msgEthereumClaim: &types.MsgEthereumClaim{
+			msgEthereumClaim: &bridgeTypes.MsgEthereumClaim{
 				Data: populateWithClaims(validClaim(), 24),
 			},
 			errStr: "",
 		},
 		{
 			name: "max claims and votes, valid",
-			msgEthereumClaim: &types.MsgEthereumClaim{
+			msgEthereumClaim: &bridgeTypes.MsgEthereumClaim{
 				Data: populateWithClaims(validClaim(), 25),
 			},
 			errStr: "",
 		},
 		{
 			name: "too may claims",
-			msgEthereumClaim: &types.MsgEthereumClaim{
+			msgEthereumClaim: &bridgeTypes.MsgEthereumClaim{
 				Data: populateWithClaims(validClaim(), 26),
 			},
 			errStr: "maximum number of claims is 25 but received 26: Invalid MsgEthereumClaimAnteHandler",
 		},
 		{
 			name: "invalid claim data",
-			msgEthereumClaim: &types.MsgEthereumClaim{
-				Data: populateWithClaims(types.ClaimData{
+			msgEthereumClaim: &bridgeTypes.MsgEthereumClaim{
+				Data: populateWithClaims(bridgeTypes.ClaimData{
 					TxHash:             []byte{},
 					ClaimNonce:         1,
-					ClaimType:          types.ClaimType_Delegate,
-					EthereumAddresses:  []types2.EthereumAddress{{1, 2, 3, 4}},
-					ConsensusAddresses: []types2.ConsensusAddress{{1, 2, 3, 4}},
+					ClaimType:          bridgeTypes.ClaimType_Delegate,
+					EthereumAddresses:  []sharedTypes.EthereumAddress{{1, 2, 3, 4}},
+					ConsensusAddresses: []sharedTypes.ConsensusAddress{{1, 2, 3, 4}},
 					Values:             []uint64{1, 2, 3, 4},
 				}, 1),
 			},
@@ -95,11 +95,11 @@ func TestNewMsgEthereumClaimAnteHandler(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			paramsProvider := paramsProvider{p: types.DefaultParams()}
+			paramsProvider := paramsProvider{p: bridgeTypes.DefaultParams()}
 
-			handler := sdk.ChainAnteDecorators(NewMsgEthereumClaimAnteHandler(paramsProvider))
-			ctx := sdk.Context{}
-			tx := TxTest{msgs: []sdk.Msg{test.msgEthereumClaim}}
+			handler := sdkTypes.ChainAnteDecorators(NewMsgEthereumClaimAnteHandler(paramsProvider))
+			ctx := sdkTypes.Context{}
+			tx := TxTest{msgs: []sdkTypes.Msg{test.msgEthereumClaim}}
 
 			_, err := handler(ctx, tx, true)
 			if len(test.errStr) > 0 {

--- a/x/bridge/handler.go
+++ b/x/bridge/handler.go
@@ -2,34 +2,35 @@ package bridge
 
 import (
 	"fmt"
+	poolTypes "github.com/bloxapp/pools-network/x/poolsnetwork/types"
 
 	"github.com/bloxapp/pools-network/x/bridge/keeper"
-	"github.com/bloxapp/pools-network/x/bridge/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	bridgeTypes "github.com/bloxapp/pools-network/x/bridge/types"
+	sdkTypes "github.com/cosmos/cosmos-sdk/types"
+	sdkErrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 // NewHandler ...
-func NewHandler(k keeper.Keeper) sdk.Handler {
-	return func(ctx sdk.Context, msg sdk.Msg) (*sdk.Result, error) {
-		ctx = ctx.WithEventManager(sdk.NewEventManager())
+func NewHandler(k keeper.Keeper) sdkTypes.Handler {
+	return func(ctx sdkTypes.Context, msg sdkTypes.Msg) (*sdkTypes.Result, error) {
+		ctx = ctx.WithEventManager(sdkTypes.NewEventManager())
 
 		switch msg := msg.(type) {
 		// this line is used by starport scaffolding # 1
-		case *types.MsgEthereumClaim:
+		case *bridgeTypes.MsgEthereumClaim:
 			return HandleMsgEthereumClaim(ctx, k, msg)
 		default:
-			errMsg := fmt.Sprintf("unrecognized %s message type: %T", types.ModuleName, msg)
-			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, errMsg)
+			errMsg := fmt.Sprintf("unrecognized %s message type: %T", poolTypes.ModuleName, msg)
+			return nil, sdkErrors.Wrap(sdkErrors.ErrUnknownRequest, errMsg)
 		}
 	}
 }
 
-func HandleMsgEthereumClaim(ctx sdk.Context, keeper keeper.Keeper, msg *types.MsgEthereumClaim) (*sdk.Result, error) {
+func HandleMsgEthereumClaim(ctx sdkTypes.Context, keeper keeper.Keeper, msg *bridgeTypes.MsgEthereumClaim) (*sdkTypes.Result, error) {
 	// validate operator
 	operator, found, err := keeper.PoolsKeeper.GetOperator(ctx, msg.ConsensusAddress)
 	if !found {
-		return nil, types.ErrOperatorNotFound
+		return nil, poolTypes.ErrOperatorNotFound
 	}
 	if err != nil {
 		return nil, err
@@ -38,21 +39,21 @@ func HandleMsgEthereumClaim(ctx sdk.Context, keeper keeper.Keeper, msg *types.Ms
 	// validate bridge contract
 	contract, found, err := keeper.GetEthereumBridgeContract(ctx, msg.ContractAddress)
 	if !found {
-		return nil, types.ErrBridgeContractNotFound
+		return nil, bridgeTypes.ErrBridgeContractNotFound
 	}
 	if err != nil {
 		return nil, err
 	}
 	if contract.ChainId != msg.EthereumChainId {
-		return nil, types.ErrWrongEthereumChainId
+		return nil, bridgeTypes.ErrWrongEthereumChainId
 	}
 
 	// validate nonce
 	lastNonce := keeper.GetLastEthereumClaimNonce(ctx, operator.ConsensusAddress)
 	if msg.Nonce != lastNonce.Uint64()+1 {
-		return nil, sdkerrors.Wrap(types.ErrNonceInvalid, "non contiguous claim nonce")
+		return nil, sdkErrors.Wrap(bridgeTypes.ErrNonceInvalid, "non contiguous claim nonce")
 	}
-	keeper.SetLastEthereumClaimNonce(ctx, operator.ConsensusAddress, types.UInt64Nonce(msg.Nonce))
+	keeper.SetLastEthereumClaimNonce(ctx, operator.ConsensusAddress, bridgeTypes.UInt64Nonce(msg.Nonce))
 
 	// add claims
 	for _, c := range msg.Data {
@@ -61,7 +62,7 @@ func HandleMsgEthereumClaim(ctx sdk.Context, keeper keeper.Keeper, msg *types.Ms
 			return nil, err
 		}
 	}
-	return &sdk.Result{
+	return &sdkTypes.Result{
 		Data:   nil,
 		Log:    "",
 		Events: nil,

--- a/x/bridge/handler_test.go
+++ b/x/bridge/handler_test.go
@@ -9,39 +9,39 @@ import (
 
 	testing2 "github.com/bloxapp/pools-network/shared/testing"
 
-	types3 "github.com/bloxapp/pools-network/x/poolsnetwork/types"
+	poolTypes "github.com/bloxapp/pools-network/x/poolsnetwork/types"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkTypes "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/stretchr/testify/require"
 
-	types2 "github.com/bloxapp/pools-network/shared/types"
+	sharedTypes "github.com/bloxapp/pools-network/shared/types"
 
-	"github.com/bloxapp/pools-network/x/bridge/types"
+	bridgeTypes "github.com/bloxapp/pools-network/x/bridge/types"
 
 	"github.com/bloxapp/pools-network/x/bridge/keeper"
 )
 
-func setupEnv(t *testing.T) (keeper.Keeper, sdk.Context, []sdk.AccAddress) {
+func setupEnv(t *testing.T) (keeper.Keeper, sdkTypes.Context, []sdkTypes.AccAddress) {
 	t.Helper()
 	app, ctx, accounts := testing2.SetupAppForTesting(false)
 
 	// generate pk for operator
 	pk := ed25519.GenPrivKey().PubKey()
-	encoded, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, pk)
+	encoded, err := sdkTypes.Bech32ifyPubKey(sdkTypes.Bech32PubKeyTypeConsPub, pk)
 	require.NoError(t, err)
 
-	err = app.BridgeKeeper.PoolsKeeper.CreateOperator(ctx, types3.Operator{
-		EthereumAddress:  types2.EthereumAddress{1, 2, 3, 4},
-		ConsensusAddress: types2.ConsensusAddress(accounts[0]),
+	err = app.BridgeKeeper.PoolsKeeper.CreateOperator(ctx, poolTypes.Operator{
+		EthereumAddress:  sharedTypes.EthereumAddress{1, 2, 3, 4},
+		ConsensusAddress: sharedTypes.ConsensusAddress(accounts[0]),
 		ConsensusPk:      encoded,
 		EthStake:         10,
 		CdtBalance:       10,
 	})
 	require.NoError(t, err)
 
-	err = app.BridgeKeeper.SetEthereumBridgeContract(ctx, types.EthereumBridgeContact{
-		ContractAddress: types2.EthereumAddress{1, 2, 3, 4},
+	err = app.BridgeKeeper.SetEthereumBridgeContract(ctx, bridgeTypes.EthereumBridgeContact{
+		ContractAddress: sharedTypes.EthereumAddress{1, 2, 3, 4},
 		ChainId:         1,
 	})
 	require.NoError(t, err)
@@ -52,35 +52,35 @@ func setupEnv(t *testing.T) (keeper.Keeper, sdk.Context, []sdk.AccAddress) {
 func TestHandleMsgEthereumClaim(t *testing.T) {
 	tests := []struct {
 		name          string
-		msg           *types.MsgEthereumClaim
+		msg           *bridgeTypes.MsgEthereumClaim
 		accountIndex  uint64
 		expectedError string
 	}{
 		{
 			name:          "valid",
-			msg:           types.NewMsgEthereumClaim(1, 1, types2.EthereumAddress{1, 2, 3, 4}, nil),
+			msg:           bridgeTypes.NewMsgEthereumClaim(1, 1, sharedTypes.EthereumAddress{1, 2, 3, 4}, nil),
 			accountIndex:  0,
 			expectedError: "",
 		},
 		{
 			name:          "invalid operator",
-			msg:           types.NewMsgEthereumClaim(1, 1, types2.EthereumAddress{1, 2, 3, 4}, nil),
+			msg:           bridgeTypes.NewMsgEthereumClaim(1, 1, sharedTypes.EthereumAddress{1, 2, 3, 4}, nil),
 			accountIndex:  1,
 			expectedError: "Operator not found",
 		},
 		{
 			name:          "invalid contract address",
-			msg:           types.NewMsgEthereumClaim(1, 1, types2.EthereumAddress{1, 2, 3, 5}, nil),
+			msg:           bridgeTypes.NewMsgEthereumClaim(1, 1, sharedTypes.EthereumAddress{1, 2, 3, 5}, nil),
 			expectedError: "Ethereum bridge contract not found",
 		},
 		{
 			name:          "invalid contract chain id",
-			msg:           types.NewMsgEthereumClaim(1, 0, types2.EthereumAddress{1, 2, 3, 4}, nil),
+			msg:           bridgeTypes.NewMsgEthereumClaim(1, 0, sharedTypes.EthereumAddress{1, 2, 3, 4}, nil),
 			expectedError: "Ethereum chain id is wrong",
 		},
 		{
 			name:          "invalid nonce",
-			msg:           types.NewMsgEthereumClaim(0, 1, types2.EthereumAddress{1, 2, 3, 4}, nil),
+			msg:           bridgeTypes.NewMsgEthereumClaim(0, 1, sharedTypes.EthereumAddress{1, 2, 3, 4}, nil),
 			expectedError: "non contiguous claim nonce: Nonce invalid",
 		},
 	}
@@ -90,7 +90,7 @@ func TestHandleMsgEthereumClaim(t *testing.T) {
 			keeper, ctx, accounts := setupEnv(t)
 
 			// replace the nil consensus address
-			test.msg.ConsensusAddress = types2.ConsensusAddress(accounts[test.accountIndex])
+			test.msg.ConsensusAddress = sharedTypes.ConsensusAddress(accounts[test.accountIndex])
 
 			res, err := bridge.HandleMsgEthereumClaim(
 				ctx,

--- a/x/bridge/keeper/attestations.go
+++ b/x/bridge/keeper/attestations.go
@@ -4,7 +4,7 @@ import (
 	bridgeTypes "github.com/bloxapp/pools-network/x/bridge/types"
 	poolTypes "github.com/bloxapp/pools-network/x/poolsnetwork/types"
 	sdkTypes "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkErrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 )
 
@@ -30,23 +30,22 @@ func (k Keeper) ProcessAttestation(ctx sdkTypes.Context, attestation *bridgeType
 	case bridgeTypes.ClaimType_Undelegate:
 		return nil
 	case bridgeTypes.ClaimType_CreateOperator:
-		//1. Prepare operator's addresses and keys
 		operatorAddress := claim.EthereumAddresses[0]
 		consensusAddress := claim.ConsensusAddresses[0]
-		publicKey := ed25519.GenPrivKey().PubKey() //TODO: find how to get Consensus Pk from ConsensusAddress?
+		publicKey := ed25519.GenPrivKey().PubKey()
 		encoded, err := sdkTypes.Bech32ifyPubKey(sdkTypes.Bech32PubKeyTypeConsPub, publicKey)
 		if err != nil {
-			return sdkerrors.Wrap(err, "could not encode Consensus public key")
+			return sdkErrors.Wrap(err, "could not encode Consensus public key")
 		}
-		//2. Structure Operator data
+
 		operator := poolTypes.Operator{
 			EthereumAddress:  operatorAddress,
 			ConsensusAddress: consensusAddress,
 			ConsensusPk:      encoded,
 		}
-		//3. Perform CreateOperator function via Keeper
+
 		if err := k.PoolsKeeper.CreateOperator(ctx, operator); err != nil {
-			return sdkerrors.Wrap(err, "could not create operator")
+			return sdkErrors.Wrap(err, "could not create operator")
 		}
 		return nil
 	default:
@@ -63,7 +62,7 @@ func (k Keeper) AttestClaim(
 ) (*bridgeTypes.ClaimAttestation, error) {
 	att, found, err := k.GetAttestation(ctx, contract, claim)
 	if err != nil {
-		return nil, sdkerrors.Wrap(err, "could not get attestation")
+		return nil, sdkErrors.Wrap(err, "could not get attestation")
 	}
 
 	if !found {
@@ -89,7 +88,7 @@ func (k Keeper) AttestClaim(
 	}
 
 	if err := k.SaveAttestation(ctx, att); err != nil {
-		return nil, sdkerrors.Wrap(err, "could not save attestation")
+		return nil, sdkErrors.Wrap(err, "could not save attestation")
 	}
 	return att, nil
 }
@@ -101,7 +100,7 @@ func (k Keeper) SaveAttestation(
 ) error {
 	byts, err := claimAttestation.Marshal()
 	if err != nil {
-		return sdkerrors.Wrap(err, "Could not marshal claim attestation")
+		return sdkErrors.Wrap(err, "Could not marshal claim attestation")
 	}
 
 	store := ctx.KVStore(k.storeKey)

--- a/x/bridge/keeper/attestations_test.go
+++ b/x/bridge/keeper/attestations_test.go
@@ -13,7 +13,7 @@ import (
 
 	sharedTypes "github.com/bloxapp/pools-network/shared/types"
 	bridgeTypes "github.com/bloxapp/pools-network/x/bridge/types"
-	"github.com/bloxapp/pools-network/x/poolsnetwork/types"
+	poolTypes "github.com/bloxapp/pools-network/x/poolsnetwork/types"
 	sdkTypes "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -88,7 +88,7 @@ func TestAttestClaim(t *testing.T) {
 				consensusAddress := sharedTypes.ConsensusAddress(account)
 				pk := randConsensusKey(t)
 
-				operator := types.Operator{
+				operator := poolTypes.Operator{
 					ConsensusAddress: consensusAddress,
 					ConsensusPk:      pk,
 					EthStake:         sdkTypes.TokensFromConsensusPower(10).Uint64(),
@@ -171,7 +171,7 @@ func TestProcessAttestation(t *testing.T) {
 	consensusAddress := sharedTypes.ConsensusAddress(account)
 	pk := randConsensusKey(t)
 
-	operator := types.Operator{
+	operator := poolTypes.Operator{
 		ConsensusAddress: consensusAddress,
 		EthereumAddress:  sharedTypes.EthereumAddress{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
 		ConsensusPk:      pk,

--- a/x/bridge/keeper/claims.go
+++ b/x/bridge/keeper/claims.go
@@ -1,49 +1,49 @@
 package keeper
 
 import (
-	"github.com/bloxapp/pools-network/shared/types"
-	types2 "github.com/bloxapp/pools-network/x/bridge/types"
-	types3 "github.com/bloxapp/pools-network/x/poolsnetwork/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sharedTypes "github.com/bloxapp/pools-network/shared/types"
+	bridgeTypes "github.com/bloxapp/pools-network/x/bridge/types"
+	poolTypes "github.com/bloxapp/pools-network/x/poolsnetwork/types"
+	sdkTypes "github.com/cosmos/cosmos-sdk/types"
+	sdkErrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 // GetEthereumBridgeContract checks and returns the contract
-func (k Keeper) GetEthereumBridgeContract(ctx sdk.Context, address types.EthereumAddress) (contract types2.EthereumBridgeContact, found bool, err error) {
+func (k Keeper) GetEthereumBridgeContract(ctx sdkTypes.Context, address sharedTypes.EthereumAddress) (contract bridgeTypes.EthereumBridgeContact, found bool, err error) {
 	store := ctx.KVStore(k.storeKey)
 	byts := store.Get(address[:])
 
 	if byts == nil || len(byts) == 0 {
-		return types2.EthereumBridgeContact{}, false, nil
+		return bridgeTypes.EthereumBridgeContact{}, false, nil
 	}
 
 	// unmarshal
-	ret := types2.EthereumBridgeContact{}
+	ret := bridgeTypes.EthereumBridgeContact{}
 	err = ret.Unmarshal(byts)
 	if err != nil {
-		return types2.EthereumBridgeContact{}, false, sdkerrors.Wrap(err, "Could not unmarshal EthereumBridgeContact")
+		return bridgeTypes.EthereumBridgeContact{}, false, sdkErrors.Wrap(err, "Could not unmarshal EthereumBridgeContact")
 	}
 
 	return ret, true, nil
 }
 
 // SetEthereumBridgeContract persists the Ethereum contract address to the KVStore
-func (k Keeper) SetEthereumBridgeContract(ctx sdk.Context, contract types2.EthereumBridgeContact) error {
+func (k Keeper) SetEthereumBridgeContract(ctx sdkTypes.Context, contract bridgeTypes.EthereumBridgeContact) error {
 	store := ctx.KVStore(k.storeKey)
 	byts, err := contract.Marshal()
 	if err != nil {
-		return sdkerrors.Wrap(err, "Could not marshal the EthereumBridgeContact.")
+		return sdkErrors.Wrap(err, "Could not marshal the EthereumBridgeContact.")
 	}
 	store.Set(contract.ContractAddress[:], byts)
 	return nil
 }
 
-// ProcessClaim process attestation after Keeper's validity checks on claim afirmation
-func (k Keeper) ProcessClaim(ctx sdk.Context, operator types3.Operator, contract types2.EthereumBridgeContact, claim types2.ClaimData) error {
+// ProcessClaim process attestation after Keeper's validity checks on claim affirmation
+func (k Keeper) ProcessClaim(ctx sdkTypes.Context, operator poolTypes.Operator, contract bridgeTypes.EthereumBridgeContact, claim bridgeTypes.ClaimData) error {
 	// add attestation and mark finalized if enough votes
 	att, err := k.AttestClaim(ctx, operator, contract, claim)
 	if err != nil {
-		return sdkerrors.Wrap(err, "could not attest claim")
+		return sdkErrors.Wrap(err, "could not attest claim")
 	}
 
 	// if finalized, process
@@ -51,17 +51,17 @@ func (k Keeper) ProcessClaim(ctx sdk.Context, operator types3.Operator, contract
 }
 
 // GetLastEthereumClaimNonce returns 0 if it's the operators first claim
-func (k Keeper) GetLastEthereumClaimNonce(ctx sdk.Context, operatorAddress types.ConsensusAddress) types2.UInt64Nonce {
+func (k Keeper) GetLastEthereumClaimNonce(ctx sdkTypes.Context, operatorAddress sharedTypes.ConsensusAddress) bridgeTypes.UInt64Nonce {
 	store := ctx.KVStore(k.storeKey)
-	bytes := store.Get(types2.GetOperatorLastClaimNonceKey(operatorAddress))
+	bytes := store.Get(bridgeTypes.GetOperatorLastClaimNonceKey(operatorAddress))
 	if len(bytes) == 0 {
-		return types2.NewUInt64Nonce(0)
+		return bridgeTypes.NewUInt64Nonce(0)
 	}
-	return types2.UInt64NonceFromBytes(bytes)
+	return bridgeTypes.UInt64NonceFromBytes(bytes)
 }
 
 // SetLastEthereumClaimNonce persists the nonce value into operator's address to the KVStore
-func (k Keeper) SetLastEthereumClaimNonce(ctx sdk.Context, operatorAddress types.ConsensusAddress, nonce types2.UInt64Nonce) {
+func (k Keeper) SetLastEthereumClaimNonce(ctx sdkTypes.Context, operatorAddress sharedTypes.ConsensusAddress, nonce bridgeTypes.UInt64Nonce) {
 	store := ctx.KVStore(k.storeKey)
-	store.Set(types2.GetOperatorLastClaimNonceKey(operatorAddress), nonce.Bytes())
+	store.Set(bridgeTypes.GetOperatorLastClaimNonceKey(operatorAddress), nonce.Bytes())
 }

--- a/x/bridge/keeper/common_test.go
+++ b/x/bridge/keeper/common_test.go
@@ -6,10 +6,10 @@ import (
 	"github.com/bloxapp/pools-network/x/bridge/keeper"
 
 	testing2 "github.com/bloxapp/pools-network/shared/testing"
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkTypes "github.com/cosmos/cosmos-sdk/types"
 )
 
-func CreateTestEnv(t *testing.T) (keeper.Keeper, sdk.Context, []sdk.AccAddress) {
+func CreateTestEnv(t *testing.T) (keeper.Keeper, sdkTypes.Context, []sdkTypes.AccAddress) {
 	t.Helper()
 	app, ctx, accounts := testing2.SetupAppForTesting(false)
 

--- a/x/bridge/keeper/keeper.go
+++ b/x/bridge/keeper/keeper.go
@@ -3,24 +3,24 @@ package keeper
 import (
 	"fmt"
 
-	types3 "github.com/bloxapp/pools-network/shared/types"
+	sharedTypes "github.com/bloxapp/pools-network/shared/types"
 	poolTypes "github.com/bloxapp/pools-network/x/poolsnetwork/types"
 
-	types2 "github.com/cosmos/cosmos-sdk/x/params/types"
+	sdkParamTypes "github.com/cosmos/cosmos-sdk/x/params/types"
 
 	"github.com/tendermint/tendermint/libs/log"
 
-	"github.com/bloxapp/pools-network/x/bridge/types"
+	bridgeTypes "github.com/bloxapp/pools-network/x/bridge/types"
 	"github.com/cosmos/cosmos-sdk/codec"
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkTypes "github.com/cosmos/cosmos-sdk/types"
 )
 
 // Keeper maintains the link to storage and exposes getter/setter methods for the various parts of the state machine
 type (
 	Keeper struct {
 		cdc        codec.Marshaler
-		storeKey   sdk.StoreKey
-		paramstore types2.Subspace
+		storeKey   sdkTypes.StoreKey
+		paramstore sdkParamTypes.Subspace
 
 		PoolsKeeper PoolKeeper
 	}
@@ -28,19 +28,19 @@ type (
 
 // PoolKeeper contains all necessary interfaces for the pool keeper, created to prevenet cyclic import
 type PoolKeeper interface {
-	GetOperator(ctx sdk.Context, address types3.ConsensusAddress) (operator poolTypes.Operator, found bool, err error)
-	GetOperatorByEthereumAddress(ctx sdk.Context, address types3.EthereumAddress) (operator poolTypes.Operator, found bool, err error)
-	CreateOperator(ctx sdk.Context, operator poolTypes.Operator) error
-	GetLastTotalPower(ctx sdk.Context) uint64
-	CreateDelegator(ctx sdk.Context, address sdk.AccAddress, balance uint64)
-	Delegate(ctx sdk.Context, from sdk.AccAddress, to poolTypes.Operator, amount sdk.Int) error
+	GetOperator(ctx sdkTypes.Context, address sharedTypes.ConsensusAddress) (operator poolTypes.Operator, found bool, err error)
+	GetOperatorByEthereumAddress(ctx sdkTypes.Context, address sharedTypes.EthereumAddress) (operator poolTypes.Operator, found bool, err error)
+	CreateOperator(ctx sdkTypes.Context, operator poolTypes.Operator) error
+	GetLastTotalPower(ctx sdkTypes.Context) uint64
+	CreateDelegator(ctx sdkTypes.Context, address sdkTypes.AccAddress, balance uint64)
+	Delegate(ctx sdkTypes.Context, from sdkTypes.AccAddress, to poolTypes.Operator, amount sdkTypes.Int) error
 }
 
-// NewKeeper returns a Keeper structure based on a marshaler, paramStore, storeKey, and poolsKeeper
-func NewKeeper(cdc codec.Marshaler, paramstore types2.Subspace, storeKey sdk.StoreKey, poolsKeeper PoolKeeper) Keeper {
+// NewKeeper returns a Keeper structure based on a marshaller, paramStore, storeKey, and poolsKeeper
+func NewKeeper(cdc codec.Marshaler, paramstore sdkParamTypes.Subspace, storeKey sdkTypes.StoreKey, poolsKeeper PoolKeeper) Keeper {
 	// set KeyTable if it has not already been set
 	if !paramstore.HasKeyTable() {
-		paramstore = paramstore.WithKeyTable(types.ParamKeyTable())
+		paramstore = paramstore.WithKeyTable(bridgeTypes.ParamKeyTable())
 	}
 
 	return Keeper{
@@ -52,6 +52,6 @@ func NewKeeper(cdc codec.Marshaler, paramstore types2.Subspace, storeKey sdk.Sto
 }
 
 // Logger returns a logger to represent its modules name
-func (k Keeper) Logger(ctx sdk.Context) log.Logger {
-	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
+func (k Keeper) Logger(ctx sdkTypes.Context) log.Logger {
+	return ctx.Logger().With("module", fmt.Sprintf("x/%s", bridgeTypes.ModuleName))
 }

--- a/x/bridge/keeper/querier.go
+++ b/x/bridge/keeper/querier.go
@@ -2,17 +2,17 @@ package keeper
 
 import (
 	// this line is used by starport scaffolding # 1
-	"github.com/bloxapp/pools-network/x/bridge/types"
+	bridgeTypes "github.com/bloxapp/pools-network/x/bridge/types"
 	"github.com/cosmos/cosmos-sdk/codec"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkTypes "github.com/cosmos/cosmos-sdk/types"
+	sdkErrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 )
 
-// NewQuerier implements the sdk.Querier function to serve as module level router for state queries
-func NewQuerier(k Keeper, legacyQuerierCdc *codec.LegacyAmino) sdk.Querier {
-	return func(ctx sdk.Context, path []string, req abci.RequestQuery) ([]byte, error) {
+// NewQuerier implements the sdkTypes.Querier function to serve as module level router for state queries
+func NewQuerier(k Keeper, legacyQuerierCdc *codec.LegacyAmino) sdkTypes.Querier {
+	return func(ctx sdkTypes.Context, path []string, req abci.RequestQuery) ([]byte, error) {
 		var (
 			res []byte
 			err error
@@ -21,7 +21,7 @@ func NewQuerier(k Keeper, legacyQuerierCdc *codec.LegacyAmino) sdk.Querier {
 		switch path[0] {
 		// this line is used by starport scaffolding # 1
 		default:
-			err = sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint: %s", types.ModuleName, path[0])
+			err = sdkErrors.Wrapf(sdkErrors.ErrUnknownRequest, "unknown %s query endpoint: %s", bridgeTypes.ModuleName, path[0])
 		}
 
 		return res, err

--- a/x/bridge/module.go
+++ b/x/bridge/module.go
@@ -9,17 +9,17 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
 
-	abci "github.com/tendermint/tendermint/abci/types"
+	abciTypes "github.com/tendermint/tendermint/abci/types"
 
-	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
-	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/bloxapp/pools-network/x/bridge/keeper"
-	"github.com/bloxapp/pools-network/x/bridge/types"
 	"github.com/bloxapp/pools-network/x/bridge/client/cli"
 	"github.com/bloxapp/pools-network/x/bridge/client/rest"
+	"github.com/bloxapp/pools-network/x/bridge/keeper"
+	bridgeTypes "github.com/bloxapp/pools-network/x/bridge/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	cdcTypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdkTypes "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
 )
 
 var (
@@ -42,32 +42,32 @@ func NewAppModuleBasic(cdc codec.Marshaler) AppModuleBasic {
 
 // Name returns the capability module's name.
 func (AppModuleBasic) Name() string {
-	return types.ModuleName
+	return bridgeTypes.ModuleName
 }
 
 func (AppModuleBasic) RegisterCodec(cdc *codec.LegacyAmino) {
-	types.RegisterCodec(cdc)
+	bridgeTypes.RegisterCodec(cdc)
 }
 
 func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-	types.RegisterCodec(cdc)
+	bridgeTypes.RegisterCodec(cdc)
 }
 
 // RegisterInterfaces registers the module's interface types
-func (a AppModuleBasic) RegisterInterfaces(reg cdctypes.InterfaceRegistry) {
-	types.RegisterInterfaces(reg)
+func (a AppModuleBasic) RegisterInterfaces(reg cdcTypes.InterfaceRegistry) {
+	bridgeTypes.RegisterInterfaces(reg)
 }
 
 // DefaultGenesis returns the capability module's default genesis state.
 func (AppModuleBasic) DefaultGenesis(cdc codec.JSONMarshaler) json.RawMessage {
-	return cdc.MustMarshalJSON(types.DefaultGenesis())
+	return cdc.MustMarshalJSON(bridgeTypes.DefaultGenesis())
 }
 
 // ValidateGenesis performs genesis state validation for the capability module.
 func (AppModuleBasic) ValidateGenesis(cdc codec.JSONMarshaler, config client.TxEncodingConfig, bz json.RawMessage) error {
-	var genState types.GenesisState
+	var genState bridgeTypes.GenesisState
 	if err := cdc.UnmarshalJSON(bz, &genState); err != nil {
-		return fmt.Errorf("failed to unmarshal %s genesis state: %w", types.ModuleName, err)
+		return fmt.Errorf("failed to unmarshal %s genesis state: %w", bridgeTypes.ModuleName, err)
 	}
 	return genState.Validate()
 }
@@ -83,12 +83,12 @@ func (a AppModuleBasic) RegisterGRPCRoutes(_ client.Context, _ *runtime.ServeMux
 
 // GetTxCmd returns the capability module's root tx command.
 func (a AppModuleBasic) GetTxCmd() *cobra.Command {
-    return cli.GetTxCmd()
+	return cli.GetTxCmd()
 }
 
 // GetQueryCmd returns the capability module's root query command.
 func (AppModuleBasic) GetQueryCmd() *cobra.Command {
-    return cli.GetQueryCmd(types.StoreKey)
+	return cli.GetQueryCmd(bridgeTypes.StoreKey)
 }
 
 // ----------------------------------------------------------------------------
@@ -115,50 +115,50 @@ func (am AppModule) Name() string {
 }
 
 // Route returns the capability module's message routing key.
-func (am AppModule) Route() sdk.Route {
-	return sdk.NewRoute(types.RouterKey, NewHandler(am.keeper))
+func (am AppModule) Route() sdkTypes.Route {
+	return sdkTypes.NewRoute(bridgeTypes.RouterKey, NewHandler(am.keeper))
 }
 
 // QuerierRoute returns the capability module's query routing key.
 func (AppModule) QuerierRoute() string { return "" }
 
 // LegacyQuerierHandler returns the capability module's Querier.
-func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sdk.Querier {
+func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sdkTypes.Querier {
 	return keeper.NewQuerier(am.keeper, legacyQuerierCdc)
 }
 
 // RegisterQueryService registers a GRPC query service to respond to the
 // module-specific GRPC queries.
 func (am AppModule) RegisterQueryService(server grpc.Server) {
-	types.RegisterQueryServer(server, am.keeper)
+	bridgeTypes.RegisterQueryServer(server, am.keeper)
 }
 
 // RegisterInvariants registers the capability module's invariants.
-func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
+func (am AppModule) RegisterInvariants(_ sdkTypes.InvariantRegistry) {}
 
 // InitGenesis performs the capability module's genesis initialization It returns
 // no validator updates.
-func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONMarshaler, gs json.RawMessage) []abci.ValidatorUpdate {
-	var genState types.GenesisState
+func (am AppModule) InitGenesis(ctx sdkTypes.Context, cdc codec.JSONMarshaler, gs json.RawMessage) []abciTypes.ValidatorUpdate {
+	var genState bridgeTypes.GenesisState
 	// Initialize global index to index in genesis state
 	cdc.MustUnmarshalJSON(gs, &genState)
 
 	InitGenesis(ctx, am.keeper, genState)
 
-	return []abci.ValidatorUpdate{}
+	return []abciTypes.ValidatorUpdate{}
 }
 
 // ExportGenesis returns the capability module's exported genesis state as raw JSON bytes.
-func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONMarshaler) json.RawMessage {
+func (am AppModule) ExportGenesis(ctx sdkTypes.Context, cdc codec.JSONMarshaler) json.RawMessage {
 	genState := ExportGenesis(ctx, am.keeper)
 	return cdc.MustMarshalJSON(genState)
 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the capability module.
-func (am AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
+func (am AppModule) BeginBlock(_ sdkTypes.Context, _ abciTypes.RequestBeginBlock) {}
 
 // EndBlock executes all ABCI EndBlock logic respective to the capability module. It
 // returns no validator updates.
-func (am AppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
-	return []abci.ValidatorUpdate{}
+func (am AppModule) EndBlock(_ sdkTypes.Context, _ abciTypes.RequestEndBlock) []abciTypes.ValidatorUpdate {
+	return []abciTypes.ValidatorUpdate{}
 }


### PR DESCRIPTION
Issue Reference: https://github.com/bloxapp/pools-network/issues/8

- Minor: renamed import reference for meaningful understading
- Operator: added support for **CreateOperator** ClaimType in **attestation.go**
- Tests: added unit tests in Attestations for ProcessAttestation **CreateOperator** 


@alonmuroch please help me to review and clarify.